### PR TITLE
Add self-contained Yaci devnet for integration testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+# pci-contracts Makefile
+# Run 'make help' to see available targets
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: dev
+dev: ## Start Yaci devnet (docker compose up -d)
+	docker compose up -d
+
+.PHONY: down
+down: ## Stop devnet and remove volumes
+	docker compose down -v
+
+.PHONY: logs
+logs: ## Tail devnet logs
+	docker compose logs -f
+
+.PHONY: status
+status: ## Check devnet health
+	@echo "Devnet containers:"
+	@docker compose ps
+	@echo ""
+	@echo "Yaci Store API:"
+	@curl -s http://localhost:8080/api/v1/blocks/latest | head -c 200 || echo "Not responding"
+	@echo ""
+
+.PHONY: test
+test: ## Run unit tests
+	pnpm test:run
+
+.PHONY: test-int
+test-int: ## Run integration tests (requires devnet running)
+	pnpm test:integration
+
+.PHONY: test-all
+test-all: ## Run all tests
+	pnpm test:run && pnpm test:integration
+
+.PHONY: lint
+lint: ## Type check with TypeScript
+	pnpm lint
+
+.PHONY: build
+build: ## Build the package
+	pnpm build
+
+.PHONY: clean
+clean: ## Clean build artifacts
+	pnpm clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,60 @@
-services:
-  contracts:
-    build: .
-    volumes:
-      - ./plutus:/app/plutus
-    environment:
-      - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
-      - CARDANO_NETWORK=preview
+# Docker Compose for pci-contracts integration testing
+# Provides a local Cardano devnet (Yaci) for S-PAL validator deployment tests
+#
+# Usage:
+#   docker compose up -d              # Start Yaci devnet
+#   pnpm test:integration             # Run integration tests
+#   docker compose down -v            # Stop and clean up
 
-  # Cardano node for local testing (optional, heavy)
-  cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:9.2.1
+services:
+  # Cardano Devnet (Yaci) - for S-PAL contract testing
+  cardano-devnet:
+    image: bloxbean/yaci-cli:0.10.6
+    ports:
+      - "8080:8080"   # Yaci Store API
+      - "10000:10000" # Cluster API
+      - "3001:3001"   # N2N port
+      - "8090:8090"   # Submit API
+      - "1337:1337"   # Ogmios
+      - "1442:1442"   # Kupo
     volumes:
-      - cardano-data:/data
-      - cardano-ipc:/ipc
+      - cardano-data:/clusters
+      - ./scripts/yaci-entrypoint.sh:/entrypoint.sh:ro
     environment:
-      - NETWORK=preview
+      - yaci_store_enabled=true
+      - ogmios_enabled=true
+      - kupo_enabled=true
+      - yaci_cli_mode=native
+      - yaci_store_mode=native
+    entrypoint: ["/bin/bash", "/entrypoint.sh"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v1/blocks/latest"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      - pci-contracts
+
+  # Optional: Yaci Viewer for debugging
+  cardano-viewer:
+    image: bloxbean/yaci-viewer:0.10.6
+    ports:
+      - "5173:5173"
+    environment:
+      - PUBLIC_INDEXER_BASE_URL=http://cardano-devnet:8080/api/v1
+      - PUBLIC_INDEXER_WS_URL=ws://localhost:8080/ws/liveblocks
+      - IS_DOCKER=true
+    depends_on:
+      - cardano-devnet
     profiles:
-      - with-node
+      - viewer
+    networks:
+      - pci-contracts
+
+networks:
+  pci-contracts:
+    driver: bridge
 
 volumes:
   cardano-data:
-  cardano-ipc:

--- a/scripts/yaci-entrypoint.sh
+++ b/scripts/yaci-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Auto-start yaci devnet node
+# The create-node command runs in foreground and manages all processes
+
+echo "Creating and starting Cardano devnet..."
+exec /app/yaci-cli create-node -o --start

--- a/src/validators/spal-enforcer.ts
+++ b/src/validators/spal-enforcer.ts
@@ -124,6 +124,16 @@ export class SPALEnforcer {
   }
 
   /**
+   * Get the Lucid instance (requires initLucid first)
+   */
+  getLucid(): LucidEvolution {
+    if (!this.lucid) {
+      throw new Error("Lucid not initialized. Call initLucid first.");
+    }
+    return this.lucid;
+  }
+
+  /**
    * Validate a request against a policy (off-chain simulation)
    *
    * This performs validation logic that mirrors the on-chain contract

--- a/tests/integration/devnet-deploy.test.ts
+++ b/tests/integration/devnet-deploy.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for S-PAL validator deployment on Yaci devnet
  *
  * Prerequisites:
- * - Yaci devnet running: cd pci-demo && docker compose up -d
+ * - Start Yaci devnet: docker compose up -d
  * - Validator built: cd spal_validator && aiken build
  *
  * Run: pnpm test:integration
@@ -10,15 +10,24 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import { existsSync, readFileSync } from "node:fs";
+import { SPALEnforcer } from "../../src/validators/spal-enforcer.js";
+import { selectWalletFromSeed } from "../../src/lucid/provider.js";
+import type { SPALPolicy, LucidConfig } from "../../src/types.js";
 
 const YACI_STORE_URL = process.env.YACI_STORE_URL || "http://localhost:8080";
+const OGMIOS_URL = process.env.OGMIOS_URL || "http://localhost:1337";
 const BLUEPRINT_PATH = "./spal_validator/plutus.json";
+
+// Yaci devkit test mnemonic - 20 pre-funded addresses with 10k ADA each
+const TEST_MNEMONIC =
+  "test test test test test test test test test test test test test test test test test test test test test test test sauce";
 
 describe("Devnet Deployment", () => {
   let isDevnetAvailable = false;
+  let isOgmiosAvailable = false;
 
   beforeAll(async () => {
-    // Check if devnet is running
+    // Check if devnet is running (Yaci Store API)
     try {
       const response = await fetch(`${YACI_STORE_URL}/api/v1/blocks/latest`, {
         signal: AbortSignal.timeout(5000),
@@ -26,6 +35,23 @@ describe("Devnet Deployment", () => {
       isDevnetAvailable = response.ok;
     } catch {
       isDevnetAvailable = false;
+    }
+
+    // Check if ogmios is available (for Lucid operations)
+    try {
+      const response = await fetch(OGMIOS_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "queryNetwork/tip",
+          id: 1,
+        }),
+        signal: AbortSignal.timeout(5000),
+      });
+      isOgmiosAvailable = response.ok;
+    } catch {
+      isOgmiosAvailable = false;
     }
   });
 
@@ -62,7 +88,7 @@ describe("Devnet Deployment", () => {
   describe("Yaci Devnet", () => {
     it("should be accessible", async () => {
       if (!isDevnetAvailable) {
-        console.log("Skipping: Yaci devnet not running");
+        console.log("Skipping: Yaci devnet not running (docker compose up -d)");
         return;
       }
 
@@ -93,26 +119,115 @@ describe("Devnet Deployment", () => {
       const response = await fetch(`${YACI_STORE_URL}/api/v1/epochs/latest`);
       expect(response.ok).toBe(true);
     });
+
+    it("should have ogmios available", async () => {
+      if (!isOgmiosAvailable) {
+        console.log("Skipping: Ogmios not running (check docker compose ports)");
+        return;
+      }
+
+      const response = await fetch(OGMIOS_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "queryNetwork/tip",
+          id: 1,
+        }),
+      });
+      expect(response.ok).toBe(true);
+    });
   });
 
   describe("Validator Deployment", () => {
+    let enforcer: SPALEnforcer;
+    let testPolicy: SPALPolicy;
+
+    beforeAll(async () => {
+      // Initialize enforcer from blueprint
+      enforcer = SPALEnforcer.fromBlueprint();
+
+      // Create test policy
+      testPolicy = {
+        version: 1n,
+        ownerPkh: "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+        contextScope: "health.records",
+        minPayment: 0n,
+        requiredProofHash: "",
+        identityLinkage: {
+          ephemeralRequired: false,
+          allowPersistent: true,
+        },
+        retentionHours: 24n,
+      };
+    });
+
+    it("should create enforcer from blueprint", () => {
+      expect(enforcer.getScriptHash()).toHaveLength(56);
+      expect(enforcer.getCborHex()).toBeDefined();
+    });
+
+    it("should validate off-chain correctly", async () => {
+      const request = {
+        requesterDid: "did:key:z6MkTest...",
+        proofReference: "",
+        accessTime: Math.floor(Date.now() / 1000),
+        paymentAmount: 0n,
+      };
+
+      const result = await enforcer.validate(testPolicy, request);
+      expect(result.valid).toBe(true);
+    });
+
     it.skip("should deploy validator to devnet", async () => {
-      // TODO: Implement actual deployment test
-      // This requires:
-      // 1. Lucid/Kupmios connection to devnet
-      // 2. Funded wallet
-      // 3. Reference script creation
-      expect(true).toBe(true);
+      if (!isOgmiosAvailable) {
+        console.log("Skipping: Ogmios not available for Lucid");
+        return;
+      }
+
+      // Initialize Lucid with Yaci devnet
+      const config: LucidConfig = {
+        network: "Custom",
+        providerUrl: OGMIOS_URL,
+        networkMagic: 764824073,
+      };
+
+      await enforcer.initLucid(config);
+
+      // Select test wallet
+      selectWalletFromSeed(enforcer.getLucid(), TEST_MNEMONIC);
+
+      // Get script address
+      const scriptAddress = enforcer.getScriptAddress();
+      expect(scriptAddress).toBeDefined();
+      expect(scriptAddress).toContain("addr_test");
+
+      // Note: Actual deployment requires funded wallet
+      // This test verifies the infrastructure is ready
     });
 
     it.skip("should create test policy UTxO", async () => {
-      // TODO: Implement policy creation test
-      expect(true).toBe(true);
+      if (!isOgmiosAvailable) {
+        console.log("Skipping: Ogmios not available");
+        return;
+      }
+
+      // This test would create an actual on-chain UTxO
+      // Requires: initialized enforcer with funded wallet
+      // const txHash = await enforcer.createPolicyUtxo(testPolicy);
+      // expect(txHash).toHaveLength(64);
     });
 
-    it.skip("should validate access request", async () => {
-      // TODO: Implement validation test
-      expect(true).toBe(true);
+    it.skip("should validate access request on-chain", async () => {
+      if (!isOgmiosAvailable) {
+        console.log("Skipping: Ogmios not available");
+        return;
+      }
+
+      // This test would validate against an on-chain policy UTxO
+      // Requires: policy UTxO created in previous test
+      // const policyUtxos = await enforcer.findPolicyUtxos();
+      // expect(policyUtxos.length).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replace cardano-node setup with Yaci devkit in docker-compose
- Enable ogmios and kupo for Lucid SDK connectivity
- Update integration tests to use local devnet (remove pci-demo dependency)
- Add Makefile for dev workflow (`make dev`, `make test-int`, etc.)

## Test plan
- [x] `make dev` starts Yaci devnet successfully
- [x] `make status` shows healthy container and block production
- [x] `make test-int` passes (9 passed, 3 skipped on-chain tx tests)
- [x] `make down` cleans up containers and volumes

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a central Makefile with commands for dev, test, lint, build, clean and help.
  * Introduced a lightweight devnet service and optional debugging viewer for local development.

* **Tests**
  * Expanded integration tests with Ogmios checks and end-to-end on-/off-chain validation scaffolding.

* **Chores**
  * Added an entrypoint to streamline devnet startup and improved health checks and network/volume setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->