### PR TITLE
Fix test script to use vitest run instead of watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "dev": "tsup --watch",
     "compile": "tsx scripts/compile.ts",
     "deploy:devnet": "tsx scripts/deploy-devnet.ts",
-    "test": "vitest",
-    "test:run": "vitest run",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "lint": "tsc --noEmit",
     "clean": "rm -rf dist"


### PR DESCRIPTION
## Summary
- Change `"test": "vitest"` (watch mode) to `"test": "vitest run"` (one-shot)
- Add `"test:watch": "vitest"` for interactive development use

`pnpm test` now exits cleanly after running instead of hanging in watch mode.

## Test plan
- [x] `pnpm test` exits with code 0 (51 unit tests pass, 3 integration tests require `aiken build`)