### PR TITLE
Ignore Claude Code / agent config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ npm-debug.log*
 # Lock files (using pnpm)
 package-lock.json
 yarn.lock
+
+# Claude Code / agent config (never committed per PCI project rule)
+CLAUDE.md
+AGENTS.md
+CLAUDE.local.md
+.claude/


### PR DESCRIPTION
Adds a dedicated `.gitignore` section for agent configuration so it is never committed, per the PCI project rule ("Never commit Claude related files").

Ignored entries:
- `CLAUDE.md`
- `AGENTS.md`
- `CLAUDE.local.md`
- `.claude/`

No functional code changes.