### PR TITLE
Add CI workflow (lint, typecheck, test, build on PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    // Integration tests require a running Yaci devnet and a compiled Aiken
+    // blueprint; run them only via `pnpm test:integration`.
+    exclude: ["tests/integration/**", "node_modules/**", "dist/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
Adds a `CI` GitHub Actions workflow that runs on every pull request and on pushes to `main`. Previously only a release workflow existed — nothing validated PRs.

## Steps
`pnpm install --frozen-lockfile` → `lint` → `typecheck` → `test` → `build`
(pnpm v9 / Node 20, matching the release workflow.)

## Also restores a lost test-config fix
Excludes the devnet integration suite (`tests/integration/**`) from the default `pnpm test`. That suite requires a running Yaci devnet + a compiled Aiken blueprint (`aiken build`) and is meant to run only via `pnpm test:integration`. This fix was authored alongside the Biome PR (#12) but did not make it into that merge, so `main`'s `pnpm test` is currently broken — this PR fixes it and is required for CI to pass.

## Validation (local, against current main)
- ✅ `pnpm lint` (Biome)
- ✅ `pnpm typecheck`
- ✅ `pnpm test` — 47 unit tests pass
- ✅ `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated checks for pull requests and changes to the main branch, including linting, type checking, tests and production builds.

- **Tests**
  - Standard test runs now focus on unit tests by excluding integration tests that require additional local services and compiled resources.
  - Added documentation clarifying the prerequisites for running integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->