### PR TITLE
S-PAL: reconstruct ZK public input from trusted context, don't accept it from the prover

### DIFF
--- a/spal_validator/PUBLIC_INPUT.md
+++ b/spal_validator/PUBLIC_INPUT.md
@@ -1,0 +1,182 @@
+# S-PAL Public Input Encoding
+
+This document pins the canonical byte encoding of the S-PAL zero-knowledge
+**public input** (`pub`) and the interim **proof commitment** that binds a proof
+to it. It is the canonical artefact: the Aiken validator
+(`validators/spal.ak`), the pci-zkp circuit/prover, and any pci-spec reference
+implementation MUST reproduce this encoding **byte-for-byte**. A one-byte
+difference between any two implementations rejects every proof.
+
+Rationale and scope: see
+[pci-contracts issue #15](https://github.com/peteski22/pci-contracts/issues/15)
+and [ADR-005](https://github.com/peteski22/pci-docs/blob/main/decisions/005-cardano-l1-vs-midnight-sidechain-for-zkp.md)
+("The public-input pattern is portable").
+
+## Principle
+
+The validator **reconstructs** the public input from context it already trusts
+— it never reads a public input supplied by the prover. Every component of
+`pub` comes from the domain-separation tag (constant), the own-script hash and
+the spending output reference (script context), the policy datum (script
+parameters), or constrained redeemer components. Because the validator computes
+`pub` rather than accepting it, a proof produced for policy A cannot be replayed
+against policy B, a different requester, or a different spent UTxO.
+
+### On-chain vs off-chain assurance
+
+While ZK verification runs off-chain there is no on-chain Groth16 verifier (see
+[Non-goals](#interim-binding-no-on-chain-verifier-yet)). Every input to `pub` is
+visible on-chain, so `pub` — and therefore `blake2b_256(pub)` — is publicly
+recomputable by anyone assembling the transaction. The on-chain binding check
+therefore proves the redeemer is bound to this exact context (policy, requester,
+payment, spent UTxO); it does **not** prove that a valid proof exists.
+Proof-of-knowledge is established off-chain, where the verifier requires a valid
+proof for this `pub`. Downstream code MUST NOT treat a passing on-chain binding
+as evidence that a proof was generated.
+
+## Version
+
+- **Encoding version:** `v1`
+- **Domain-separation tag (`domain_sep_spal`):** the UTF-8 bytes of the ASCII
+  string `pci:spal:pubinput:v1` — exactly 20 bytes:
+
+  ```
+  7063693a7370616c3a707562696e7075743a7631
+  ```
+
+  Bumping the version changes every `pub`; change the tag and this document
+  together.
+
+## Public input preimage
+
+`pub` is the Blake2b-256 digest of the concatenation of the following
+components, in this exact order. Every component is **fixed-width** (a hash
+digest or a fixed-size big-endian integer), so the concatenation is unambiguous
+and needs no length delimiters.
+
+| # | Component                | Width (bytes) | Source              | Encoding                                                     |
+|---|--------------------------|---------------|---------------------|-------------------------------------------------------------|
+| 1 | `domain_sep_spal`        | 20            | constant            | UTF-8 bytes of `pci:spal:pubinput:v1` (see above)           |
+| 2 | `script_hash`            | 28            | script context      | Plutus V3 own-script hash (Blake2b-224 of the script)       |
+| 3 | `spend_ref_hash`         | 32            | script context      | Blake2b-256 of the canonical Plutus CBOR of the spending `OutputReference` |
+| 4 | `policy_hash`            | 32            | policy datum        | Blake2b-256 of the canonical Plutus CBOR of `PolicyDatum`   |
+| 5 | `context_scope_hash`     | 32            | policy datum        | Blake2b-256 of `PolicyDatum.context_scope`                  |
+| 6 | `required_proof_hash_h`  | 32            | policy datum        | Blake2b-256 of `PolicyDatum.required_proof_hash`           |
+| 7 | `subject_hash`           | 28            | redeemer            | Blake2b-224 of `AccessRedeemer.requester_did`               |
+| 8 | `access_time`            | 8             | redeemer            | `AccessRedeemer.access_time` as 8-byte big-endian           |
+| 9 | `payment_commitment`     | 32            | policy + redeemer   | see [Payment commitment](#payment-commitment)               |
+
+```text
+preimage = domain_sep_spal
+        || script_hash
+        || spend_ref_hash
+        || policy_hash
+        || context_scope_hash
+        || required_proof_hash_h
+        || subject_hash
+        || access_time
+        || payment_commitment
+
+pub = Blake2b-256(preimage)          // 32 bytes
+```
+
+`policy_hash` (component 3) already commits to the entire `PolicyDatum`,
+including `context_scope`, `required_proof_hash`, and `payment_currency`.
+Components 4, 5, and the currency portion of 8 are therefore redundant with
+`policy_hash`; they are retained deliberately so each field the circuit consumes
+is bound explicitly and mirrors the circuit's public-input layout.
+
+### Notes on each field
+
+- **`script_hash`** binds `pub` to this specific deployed script instance,
+  preventing cross-deployment replay. On-chain it is the payment credential of
+  the script's own spending input.
+- **`spend_ref_hash`** binds `pub` to the specific UTxO being spent (the
+  spending `OutputReference` — transaction id plus output index), preventing
+  replay of a commitment against another UTxO that carries an identical policy
+  and redeemer within the same deployment.
+- **`policy_hash`** is the Blake2b-256 of the Plutus **CBOR** encoding of the
+  `PolicyDatum` (Aiken `cbor.serialise`; off-chain, the same canonical Plutus
+  Data CBOR, e.g. Lucid `Data.to`). Both sides must serialise the identical
+  datum shape (7 fields, field order as in `PolicyDatum`).
+- **`access_time`** is a non-negative POSIX millisecond timestamp; 8 bytes hold
+  timestamps up to year ~292 million. A value that does not fit in 8 bytes (or
+  is negative) makes the on-chain reconstruction fail, rejecting the
+  transaction.
+
+### Payment commitment
+
+`payment_commitment` (component 8) is a fixed-width digest binding the payment
+currency and the claimed amount:
+
+```text
+currency_bytes(Ada)                              = 0x00
+currency_bytes(NativeToken{policy_id, name})     = 0x01 || policy_id || name
+
+payment_commitment = Blake2b-256(
+  amount_16be                                    // payment_amount as 16-byte big-endian
+  || currency_bytes                              // variable-length asset name is last
+)
+```
+
+The amount is encoded as 16-byte big-endian (large enough for native-token
+quantities) and placed **first** so the variable-length asset name is last and
+the preimage stays unambiguous. `policy_id` is a 28-byte Cardano policy hash and
+`asset_name` is 0–32 bytes; with the policy id fixed-width and the asset name
+last, the currency bytes are unambiguous. The currency is authored by the policy
+owner in the trusted datum and is committed by `policy_hash`, so a malformed
+`policy_id` width is not attacker-controllable at spend time.
+
+`amount_16be` uses big-endian encoding at a fixed 16-byte width. A negative or
+oversized amount cannot be encoded (Aiken `bytearray.from_int_big_endian` halts
+on values that do not fit in the requested width), which makes the on-chain
+reconstruction fail and rejects the transaction — so distinct amounts cannot
+collide.
+
+## Fr reduction (circuit side)
+
+The 32-byte `pub` digest is turned into a single field element for the Groth16
+/ Compact circuit by reducing it modulo the circuit's scalar field order `r`
+(for BLS12-381, the standard scalar field modulus):
+
+```text
+pub_field = Fr(pub) = big_endian_to_integer(pub) mod r
+```
+
+This reduction is deterministic and identical on both sides. The Aiken validator
+does not perform it: while ZK verification runs off-chain there is no on-chain
+Groth16 verifier (see issue #15 non-goals), so the validator binds the 32-byte
+digest directly (below). If an on-chain verifier is later added under ADR-005,
+it consumes `pub_field`.
+
+## Interim binding (no on-chain verifier yet)
+
+Until an on-chain Groth16 verifier exists, the validator enforces the binding
+through a commitment carried in the redeemer:
+
+- `AccessRedeemer.proof_commitment` MUST equal `Blake2b-256(pub)` whenever
+  `PolicyDatum.required_proof_hash` is non-empty.
+- When `required_proof_hash` is empty, no proof is required and
+  `proof_commitment` is unconstrained (conventionally empty).
+
+The off-chain prover is required to have produced a valid ZK proof for exactly
+this `pub` and to commit to it as `Blake2b-256(pub)`. On-chain this rejects any
+transaction whose commitment is not bound to the reconstructed `pub`; off-chain
+verification of the proof itself closes the remaining gap.
+
+```text
+proof_commitment == Blake2b-256(pub)             // required_proof_hash non-empty
+```
+
+## Off-chain reproduction checklist
+
+1. Serialise the identical `PolicyDatum` (same field order and values) to
+   canonical Plutus CBOR and Blake2b-256 it for `policy_hash`. Do the same for
+   the spending `OutputReference` to obtain `spend_ref_hash`.
+2. Use the exact `domain_sep_spal` bytes above.
+3. Encode `access_time` and `payment_amount` as big-endian at the fixed widths
+   (8 and 16 bytes).
+4. Concatenate components 1–9 in order and Blake2b-256 the result to obtain
+   `pub`.
+5. Commit `Blake2b-256(pub)` into the redeemer's `proof_commitment`.
+6. For the circuit's public input, reduce `pub` modulo `r`.

--- a/spal_validator/PUBLIC_INPUT.md
+++ b/spal_validator/PUBLIC_INPUT.md
@@ -80,9 +80,9 @@ preimage = domain_sep_spal
 pub = Blake2b-256(preimage)          // 32 bytes
 ```
 
-`policy_hash` (component 3) already commits to the entire `PolicyDatum`,
+`policy_hash` (component 4) already commits to the entire `PolicyDatum`,
 including `context_scope`, `required_proof_hash`, and `payment_currency`.
-Components 4, 5, and the currency portion of 8 are therefore redundant with
+Components 5, 6, and the currency portion of 9 are therefore redundant with
 `policy_hash`; they are retained deliberately so each field the circuit consumes
 is bound explicitly and mirrors the circuit's public-input layout.
 

--- a/spal_validator/validators/spal.ak
+++ b/spal_validator/validators/spal.ak
@@ -7,7 +7,7 @@ use aiken/crypto
 use aiken/primitive/bytearray
 use cardano/address.{Address, Credential, Script, VerificationKey}
 use cardano/assets.{from_lovelace, lovelace_of, quantity_of}
-use cardano/transaction.{NoDatum, Output, OutputReference, Transaction}
+use cardano/transaction.{Input, NoDatum, Output, OutputReference, Transaction}
 
 /// Domain-separation tag for S-PAL public inputs.
 ///
@@ -567,6 +567,93 @@ test proof_commitment_does_not_replay_across_utxos() {
   let public_input_b =
     reconstruct_public_input(sh, other_ref, sample_policy(), sample_redeemer())
   commitment_a != crypto.blake2b_256(public_input_b)
+}
+
+/// A transaction whose sole input is the policy UTxO at the given script
+/// address, signed by `owner` — the minimum context for driving `spal.spend`
+/// and resolving `own_script_hash`.
+fn spend_tx(
+  script_hash: ByteArray,
+  utxo: OutputReference,
+  owner: ByteArray,
+) -> Transaction {
+  let script_input =
+    Input {
+      output_reference: utxo,
+      output: Output {
+        address: Address {
+          payment_credential: Script(script_hash),
+          stake_credential: None,
+        },
+        value: from_lovelace(2_000_000),
+        datum: NoDatum,
+        reference_script: None,
+      },
+    }
+  Transaction {
+    ..transaction.placeholder,
+    inputs: [script_input],
+    extra_signatories: [owner],
+  }
+}
+
+/// End-to-end: a commitment computed from the resolved script hash and the
+/// spending context is accepted, exercising `own_script_hash` and the binding.
+test spend_accepts_bound_proof_commitment() {
+  let owner =
+    #"0011223344556677889900112233445566778899001122334455667788990011"
+  let script_hash = #"00112233445566778899aabbccddeeff00112233445566778899aabb"
+  let utxo = sample_spend_ref()
+  let policy = PolicyDatum { ..sample_policy(), owner: owner, min_payment: 0 }
+  let base_redeemer = AccessRedeemer { ..sample_redeemer(), payment_amount: 0 }
+  let public_input =
+    reconstruct_public_input(script_hash, utxo, policy, base_redeemer)
+  let redeemer =
+    AccessRedeemer {
+      ..base_redeemer,
+      proof_commitment: crypto.blake2b_256(public_input),
+    }
+  spal.spend(Some(policy), redeemer, utxo, spend_tx(script_hash, utxo, owner))
+}
+
+/// End-to-end: a commitment not bound to the reconstructed public input is
+/// rejected even though it is non-empty (passes the shape check).
+test spend_rejects_unbound_proof_commitment() {
+  let owner =
+    #"0011223344556677889900112233445566778899001122334455667788990011"
+  let script_hash = #"00112233445566778899aabbccddeeff00112233445566778899aabb"
+  let utxo = sample_spend_ref()
+  let policy = PolicyDatum { ..sample_policy(), owner: owner, min_payment: 0 }
+  let redeemer =
+    AccessRedeemer {
+      ..sample_redeemer(),
+      payment_amount: 0,
+      proof_commitment: #"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    }
+  !spal.spend(Some(policy), redeemer, utxo, spend_tx(script_hash, utxo, owner))
+}
+
+/// End-to-end: when the policy requires no proof, the binding short-circuits and
+/// an empty commitment is accepted.
+test spend_accepts_when_no_proof_required() {
+  let owner =
+    #"0011223344556677889900112233445566778899001122334455667788990011"
+  let script_hash = #"00112233445566778899aabbccddeeff00112233445566778899aabb"
+  let utxo = sample_spend_ref()
+  let policy =
+    PolicyDatum {
+      ..sample_policy(),
+      owner: owner,
+      min_payment: 0,
+      required_proof_hash: #"",
+    }
+  let redeemer =
+    AccessRedeemer {
+      ..sample_redeemer(),
+      payment_amount: 0,
+      proof_commitment: #"",
+    }
+  spal.spend(Some(policy), redeemer, utxo, spend_tx(script_hash, utxo, owner))
 }
 
 test payment_commitment_is_deterministic() {

--- a/spal_validator/validators/spal.ak
+++ b/spal_validator/validators/spal.ak
@@ -1,11 +1,22 @@
 // S-PAL (Sovereign Privacy & Access Language) Validator
 // Enforces data sovereignty policies on Cardano
 
+use aiken/cbor
 use aiken/collection/list
+use aiken/crypto
 use aiken/primitive/bytearray
-use cardano/address.{Address, Credential, VerificationKey}
+use cardano/address.{Address, Credential, Script, VerificationKey}
 use cardano/assets.{from_lovelace, lovelace_of, quantity_of}
 use cardano/transaction.{NoDatum, Output, OutputReference, Transaction}
+
+/// Domain-separation tag for S-PAL public inputs.
+///
+/// Prefixed into every reconstructed public input so S-PAL's `pub` values are
+/// non-collidable with any other circuit that reuses the same field. Versioned;
+/// a change here changes every `pub`. This value MUST be reproduced byte-for-byte
+/// by every off-chain prover and circuit that recomputes the public input.
+/// See PUBLIC_INPUT.md for the full encoding.
+const domain_sep_spal: ByteArray = "pci:spal:pubinput:v1"
 
 /// Identity linkage rules for privacy-preserving verification
 pub type IdentityLinkage {
@@ -32,9 +43,27 @@ pub type PolicyDatum {
 }
 
 /// Redeemer for policy access
+///
+/// `proof_commitment` is a commitment to the off-chain proof artefact, set to
+/// `blake2b_256(pub)` where `pub` is the public input the validator reconstructs
+/// from trusted context. It replaces the former opaque `proof_reference`: the
+/// prover no longer supplies a public input.
+///
+/// The on-chain check binds this commitment to the reconstructed `pub`, so it is
+/// tied to the policy, requester, payment, and the specific UTxO being spent.
+/// While ZK verification runs off-chain there is no on-chain Groth16 verifier
+/// (see PUBLIC_INPUT.md), so `pub` — and therefore `blake2b_256(pub)` — is
+/// publicly recomputable from on-chain data: the on-chain check proves the
+/// redeemer is bound to this exact context, not that a valid proof exists.
+/// Proof-of-knowledge is established off-chain, where the verifier requires a
+/// valid proof for this `pub`.
+///
+/// The remaining fields (`requester_did`, `access_time`, `payment_amount`) are
+/// the constrained inputs the validator feeds into the public-input
+/// reconstruction — never the reconstructed public input itself.
 pub type AccessRedeemer {
   requester_did: ByteArray,
-  proof_reference: ByteArray,
+  proof_commitment: ByteArray,
   access_time: Int,
   payment_amount: Int,
 }
@@ -108,23 +137,110 @@ fn check_payment(
   }
 }
 
-/// Validates proof reference exists if required
+/// Validates a proof commitment is present when the policy requires a proof.
+///
+/// Shape check only: it confirms the redeemer carries a non-empty commitment.
+/// The cryptographic binding of that commitment to the policy, requester, and
+/// transaction context is enforced separately via the reconstructed public input.
 fn check_proof_requirement(
-  proof_reference: ByteArray,
+  proof_commitment: ByteArray,
   required_proof_hash: ByteArray,
 ) -> Bool {
   if bytearray.length(required_proof_hash) == 0 {
     True
   } else {
-    bytearray.length(proof_reference) > 0
+    bytearray.length(proof_commitment) > 0
   }
+}
+
+/// Canonical byte encoding of a payment currency, used inside the payment
+/// commitment. `Ada` is the single tag byte `0x00`; a native token is the tag
+/// byte `0x01` followed by its policy id (a 28-byte Cardano policy hash) and
+/// asset name (0–32 bytes). The variable-length asset name is last, so with the
+/// fixed-width policy id and a prepended fixed-width amount the encoding is
+/// unambiguous. The currency is authored by the policy owner in the trusted
+/// datum, which is itself committed via `policy_hash`.
+fn payment_currency_bytes(currency: PaymentCurrency) -> ByteArray {
+  when currency is {
+    Ada -> #"00"
+    NativeToken { policy_id, asset_name } ->
+      #"01"
+        |> bytearray.concat(policy_id)
+        |> bytearray.concat(asset_name)
+  }
+}
+
+/// Commitment binding the payment currency and claimed amount into a fixed-width
+/// digest. The amount is encoded as 16-byte big-endian (large enough for native
+/// token quantities) and prepended to the currency bytes so the concatenation is
+/// unambiguous.
+fn payment_commitment(currency: PaymentCurrency, amount: Int) -> ByteArray {
+  let preimage =
+    bytearray.from_int_big_endian(amount, 16)
+      |> bytearray.concat(payment_currency_bytes(currency))
+  crypto.blake2b_256(preimage)
+}
+
+/// Reconstruct the S-PAL public input from context the validator already trusts.
+///
+/// Every component is derived from trusted context — the domain-separation tag
+/// (constant), the own-script hash and the spending output reference (script
+/// context), the policy datum (script parameters), and the constrained redeemer
+/// components. The prover cannot substitute a public input: the validator
+/// computes one rather than reading one. Including the spending output reference
+/// binds `pub` to the specific UTxO being spent, so a commitment produced for
+/// one spend cannot be replayed against another UTxO carrying an identical
+/// policy and redeemer.
+///
+/// All components are fixed-width — hash digests or fixed-size big-endian
+/// integers — so the concatenation is unambiguous. The exact encoding is pinned
+/// in PUBLIC_INPUT.md and MUST be reproduced byte-for-byte off-chain; a
+/// one-byte difference rejects every proof.
+fn reconstruct_public_input(
+  script_hash: ByteArray,
+  spend_ref: OutputReference,
+  policy: PolicyDatum,
+  redeemer: AccessRedeemer,
+) -> ByteArray {
+  let spend_ref_hash = crypto.blake2b_256(cbor.serialise(spend_ref))
+  let policy_hash = crypto.blake2b_256(cbor.serialise(policy))
+  let context_scope_hash = crypto.blake2b_256(policy.context_scope)
+  let required_proof_hash_hash =
+    crypto.blake2b_256(policy.required_proof_hash)
+  let subject_hash = crypto.blake2b_224(redeemer.requester_did)
+  let access_time_bytes =
+    bytearray.from_int_big_endian(redeemer.access_time, 8)
+  let payment_commitment_bytes =
+    payment_commitment(policy.payment_currency, redeemer.payment_amount)
+
+  let preimage =
+    domain_sep_spal
+      |> bytearray.concat(script_hash)
+      |> bytearray.concat(spend_ref_hash)
+      |> bytearray.concat(policy_hash)
+      |> bytearray.concat(context_scope_hash)
+      |> bytearray.concat(required_proof_hash_hash)
+      |> bytearray.concat(subject_hash)
+      |> bytearray.concat(access_time_bytes)
+      |> bytearray.concat(payment_commitment_bytes)
+
+  crypto.blake2b_256(preimage)
+}
+
+/// Resolve the hash of the currently-executing spending script from the script
+/// context. A spend validator's own input is always present and always sits at a
+/// script address, so both patterns are total for this validator.
+fn own_script_hash(tx: Transaction, utxo: OutputReference) -> ByteArray {
+  expect Some(input) = transaction.find_input(tx.inputs, utxo)
+  expect Script(hash) = input.output.address.payment_credential
+  hash
 }
 
 validator spal {
   spend(
     datum: Option<PolicyDatum>,
     redeemer: AccessRedeemer,
-    _utxo: OutputReference,
+    utxo: OutputReference,
     tx: Transaction,
   ) {
     when datum is {
@@ -134,10 +250,27 @@ validator spal {
           redeemer.requester_did,
           policy.identity_linkage,
         )
-        let proof_valid = check_proof_requirement(
-          redeemer.proof_reference,
+        let proof_shape_valid = check_proof_requirement(
+          redeemer.proof_commitment,
           policy.required_proof_hash,
         )
+        // Reconstruct the ZK public input from trusted context and require the
+        // redeemer's proof commitment to bind to it. The validator never reads a
+        // public input the prover supplied; it computes one. Only evaluated when
+        // the policy requires a proof, to avoid needless on-chain work.
+        let proof_bound =
+          if bytearray.length(policy.required_proof_hash) == 0 {
+            True
+          } else {
+            let public_input =
+              reconstruct_public_input(
+                own_script_hash(tx, utxo),
+                utxo,
+                policy,
+                redeemer,
+              )
+            redeemer.proof_commitment == crypto.blake2b_256(public_input)
+          }
         let payment_valid = check_payment(
           tx,
           policy.owner,
@@ -145,7 +278,7 @@ validator spal {
           redeemer.payment_amount,
           policy.payment_currency,
         )
-        owner_signed && identity_valid && proof_valid && payment_valid
+        owner_signed && identity_valid && proof_shape_valid && proof_bound && payment_valid
       }
       None -> False
     }
@@ -224,9 +357,233 @@ test check_proof_not_required() {
 }
 
 test check_proof_required_and_provided() {
-  let proof_ref = #"6d69646e696768743a74783a616263313233"
+  let proof_commitment = #"6d69646e696768743a74783a616263313233"
   let required_hash = #"aabbccdd"
-  check_proof_requirement(proof_ref, required_hash)
+  check_proof_requirement(proof_commitment, required_hash)
+}
+
+test check_proof_required_but_missing() {
+  let required_hash = #"aabbccdd"
+  !check_proof_requirement(#"", required_hash)
+}
+
+// Public-input reconstruction tests
+
+/// A sample policy datum for reconstruction tests.
+fn sample_policy() -> PolicyDatum {
+  PolicyDatum {
+    owner: #"0011223344556677889900112233445566778899001122334455667788990011",
+    min_payment: 1_000_000,
+    max_retention_ms: 86_400_000,
+    identity_linkage: IdentityLinkage {
+      ephemeral_required: True,
+      proof_of_root_allowed: True,
+      zk_continuity_allowed: False,
+    },
+    required_proof_hash: #"aabbccdd",
+    context_scope: #"6d65646963616c2f646961676e6f736973",
+    payment_currency: Ada,
+  }
+}
+
+/// A sample access redeemer for reconstruction tests.
+fn sample_redeemer() -> AccessRedeemer {
+  AccessRedeemer {
+    requester_did: #"6469643a6b65793a7a364d6b54657374",
+    proof_commitment: #"",
+    access_time: 1_700_000_000_000,
+    payment_amount: 2_000_000,
+  }
+}
+
+/// A sample spending output reference for reconstruction tests.
+fn sample_spend_ref() -> OutputReference {
+  OutputReference {
+    transaction_id: #"00000000000000000000000000000000000000000000000000000000000000aa",
+    output_index: 0,
+  }
+}
+
+test public_input_is_deterministic() {
+  let sh = #"deadbeef"
+  reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    sample_policy(),
+    sample_redeemer(),
+  ) == reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    sample_policy(),
+    sample_redeemer(),
+  )
+}
+
+test public_input_changes_with_script_hash() {
+  reconstruct_public_input(
+    #"deadbeef",
+    sample_spend_ref(),
+    sample_policy(),
+    sample_redeemer(),
+  ) != reconstruct_public_input(
+    #"cafebabe",
+    sample_spend_ref(),
+    sample_policy(),
+    sample_redeemer(),
+  )
+}
+
+test public_input_changes_with_spend_ref() {
+  let sh = #"deadbeef"
+  let other_ref = OutputReference { ..sample_spend_ref(), output_index: 1 }
+  reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    sample_policy(),
+    sample_redeemer(),
+  ) != reconstruct_public_input(
+    sh,
+    other_ref,
+    sample_policy(),
+    sample_redeemer(),
+  )
+}
+
+test public_input_changes_with_policy() {
+  let sh = #"deadbeef"
+  let other_policy =
+    PolicyDatum { ..sample_policy(), context_scope: #"6f74686572" }
+  reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    sample_policy(),
+    sample_redeemer(),
+  ) != reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    other_policy,
+    sample_redeemer(),
+  )
+}
+
+test public_input_changes_with_subject() {
+  let sh = #"deadbeef"
+  let other_redeemer =
+    AccessRedeemer {
+      ..sample_redeemer(),
+      requester_did: #"6469643a6b65793a7a3641414161",
+    }
+  reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    sample_policy(),
+    sample_redeemer(),
+  ) != reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    sample_policy(),
+    other_redeemer,
+  )
+}
+
+test public_input_changes_with_access_time() {
+  let sh = #"deadbeef"
+  let other_redeemer =
+    AccessRedeemer { ..sample_redeemer(), access_time: 1_700_000_000_001 }
+  reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    sample_policy(),
+    sample_redeemer(),
+  ) != reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    sample_policy(),
+    other_redeemer,
+  )
+}
+
+test public_input_changes_with_payment_amount() {
+  let sh = #"deadbeef"
+  let other_redeemer =
+    AccessRedeemer { ..sample_redeemer(), payment_amount: 3_000_000 }
+  reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    sample_policy(),
+    sample_redeemer(),
+  ) != reconstruct_public_input(
+    sh,
+    sample_spend_ref(),
+    sample_policy(),
+    other_redeemer,
+  )
+}
+
+/// A commitment produced for one subject must not satisfy the binding for
+/// another subject's public input — i.e. a proof cannot be replayed across
+/// requesters.
+test proof_commitment_does_not_replay_across_subjects() {
+  let sh = #"deadbeef"
+  let other_redeemer =
+    AccessRedeemer {
+      ..sample_redeemer(),
+      requester_did: #"6469643a6b65793a7a3641414161",
+    }
+  let commitment_a =
+    crypto.blake2b_256(
+      reconstruct_public_input(
+        sh,
+        sample_spend_ref(),
+        sample_policy(),
+        sample_redeemer(),
+      ),
+    )
+  let public_input_b =
+    reconstruct_public_input(
+      sh,
+      sample_spend_ref(),
+      sample_policy(),
+      other_redeemer,
+    )
+  commitment_a != crypto.blake2b_256(public_input_b)
+}
+
+/// A commitment produced for one UTxO must not satisfy the binding for another
+/// UTxO carrying an identical policy and redeemer — i.e. a proof cannot be
+/// replayed across UTxOs within the same deployment.
+test proof_commitment_does_not_replay_across_utxos() {
+  let sh = #"deadbeef"
+  let other_ref = OutputReference { ..sample_spend_ref(), output_index: 1 }
+  let commitment_a =
+    crypto.blake2b_256(
+      reconstruct_public_input(
+        sh,
+        sample_spend_ref(),
+        sample_policy(),
+        sample_redeemer(),
+      ),
+    )
+  let public_input_b =
+    reconstruct_public_input(sh, other_ref, sample_policy(), sample_redeemer())
+  commitment_a != crypto.blake2b_256(public_input_b)
+}
+
+test payment_commitment_is_deterministic() {
+  payment_commitment(Ada, 1_000_000) == payment_commitment(Ada, 1_000_000)
+}
+
+test payment_commitment_changes_with_amount() {
+  payment_commitment(Ada, 1_000_000) != payment_commitment(Ada, 2_000_000)
+}
+
+test payment_commitment_changes_with_currency() {
+  let token =
+    NativeToken {
+      policy_id: #"aabb00112233445566778899aabbccddeeff00112233445566778899",
+      asset_name: #"5553444378",
+    }
+  payment_commitment(Ada, 1_000_000) != payment_commitment(token, 1_000_000)
 }
 
 // Payment validation tests (Ada)

--- a/src/lucid/datum-builders.ts
+++ b/src/lucid/datum-builders.ts
@@ -115,28 +115,33 @@ export function buildPolicyDatum(policy: SPALPolicy): Constr<Data> {
  * ```
  */
 export function buildAccessRedeemer(request: ValidationRequest): Constr<Data> {
-  // proof_commitment is a hex-encoded hash. Pass hex through unchanged and
-  // utf8-encode any non-hex value so placeholder strings still serialize.
-  // Empty string stays empty (no proof required).
-  const commitmentHex = request.proofCommitment
-    ? isHex(request.proofCommitment)
-      ? request.proofCommitment
-      : stringToHex(request.proofCommitment)
-    : ""
-
   return new Constr(0, [
     stringToHex(request.requesterDid), // ByteArray (hex-encoded DID)
-    commitmentHex, // ByteArray (hex string, empty if no proof)
+    validateProofCommitment(request.proofCommitment), // ByteArray (hex, empty if no proof)
     BigInt(request.accessTime), // Int (bigint)
     request.paymentAmount, // Int (bigint)
   ])
 }
 
 /**
- * Check if a string is valid hex (even length, only hex chars)
+ * Validate a proof commitment for the access redeemer.
+ *
+ * A commitment is either an empty string (no proof required) or the hex-encoded
+ * 32-byte blake2b-256 public-input digest — exactly 64 hex characters. Validating
+ * the shape here makes a malformed commitment fail with a clear message at
+ * construction, rather than as an opaque on-chain equality mismatch.
+ *
+ * @returns the commitment unchanged (empty, or 64 hex characters)
+ * @throws Error if a non-empty commitment is not exactly 64 hex characters
  */
-function isHex(str: string): boolean {
-  return str.length % 2 === 0 && /^[0-9a-fA-F]*$/.test(str)
+function validateProofCommitment(commitment: string): string {
+  if (commitment.length === 0) return ""
+  if (!/^[0-9a-fA-F]{64}$/.test(commitment)) {
+    throw new Error(
+      `Invalid proof commitment: must be 64 hex characters (32-byte blake2b-256 digest), got "${commitment}" (${commitment.length} chars)`,
+    )
+  }
+  return commitment
 }
 
 /**

--- a/src/lucid/datum-builders.ts
+++ b/src/lucid/datum-builders.ts
@@ -108,24 +108,25 @@ export function buildPolicyDatum(policy: SPALPolicy): Constr<Data> {
  * ```aiken
  * pub type AccessRedeemer {
  *   requester_did: ByteArray,
- *   proof_reference: ByteArray,
+ *   proof_commitment: ByteArray,
  *   access_time: Int,
  *   payment_amount: Int,
  * }
  * ```
  */
 export function buildAccessRedeemer(request: ValidationRequest): Constr<Data> {
-  // Convert proof reference to hex if it's not already hex
-  // (empty string stays empty, otherwise convert)
-  const proofHex = request.proofReference
-    ? isHex(request.proofReference)
-      ? request.proofReference
-      : stringToHex(request.proofReference)
+  // proof_commitment is a hex-encoded hash. Pass hex through unchanged and
+  // utf8-encode any non-hex value so placeholder strings still serialize.
+  // Empty string stays empty (no proof required).
+  const commitmentHex = request.proofCommitment
+    ? isHex(request.proofCommitment)
+      ? request.proofCommitment
+      : stringToHex(request.proofCommitment)
     : ""
 
   return new Constr(0, [
     stringToHex(request.requesterDid), // ByteArray (hex-encoded DID)
-    proofHex, // ByteArray (hex string, empty if no proof)
+    commitmentHex, // ByteArray (hex string, empty if no proof)
     BigInt(request.accessTime), // Int (bigint)
     request.paymentAmount, // Int (bigint)
   ])

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,8 +121,15 @@ export interface ValidationRequest {
   policyId?: string
   /** Requester's DID (ephemeral did:key or persistent) */
   requesterDid: string
-  /** Reference to ZKP proof (e.g., Midnight tx hash) */
-  proofReference: string
+  /**
+   * Commitment to the off-chain ZK proof artefact, bound to the public input
+   * the validator reconstructs from trusted context (`blake2b_256(pub)`).
+   * Hex-encoded; empty string when the policy requires no proof. The prover
+   * never supplies a public input — this value can only satisfy the on-chain
+   * binding for the policy, requester, and transaction context it was produced
+   * for. See PUBLIC_INPUT.md for the encoding.
+   */
+  proofCommitment: string
   /** Access timestamp for audit */
   accessTime: number
   /** Payment amount (must meet minPayment). Units match policy's paymentCurrency. */

--- a/src/validators/spal-enforcer.ts
+++ b/src/validators/spal-enforcer.ts
@@ -193,12 +193,14 @@ export class SPALEnforcer {
       }
     }
 
-    // 3. Check proof requirement
+    // 3. Check proof commitment shape.
+    // The cryptographic binding of the commitment to the reconstructed public
+    // input is enforced on-chain; off-chain we can only confirm it is present.
     if (policy.requiredProofHash && policy.requiredProofHash.length > 0) {
-      if (!request.proofReference || request.proofReference.length === 0) {
+      if (!request.proofCommitment || request.proofCommitment.length === 0) {
         return {
           valid: false,
-          error: "Proof reference required but not provided",
+          error: "Proof commitment required but not provided",
         }
       }
     }

--- a/tests/datum-builders.test.ts
+++ b/tests/datum-builders.test.ts
@@ -42,7 +42,7 @@ describe("Datum Builders", () => {
 
   const testRequest: ValidationRequest = {
     requesterDid: "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
-    proofReference: "proof123abc",
+    proofCommitment: "proof123abc",
     accessTime: 1704067200000,
     paymentAmount: 1_000_000n,
   }
@@ -209,10 +209,10 @@ describe("Datum Builders", () => {
       expect(result.fields[3]).toBe(testRequest.paymentAmount)
     })
 
-    it("should handle empty proof reference", () => {
+    it("should handle empty proof commitment", () => {
       const requestNoProof: ValidationRequest = {
         ...testRequest,
-        proofReference: "",
+        proofCommitment: "",
       }
 
       const result = buildAccessRedeemer(requestNoProof)

--- a/tests/datum-builders.test.ts
+++ b/tests/datum-builders.test.ts
@@ -42,7 +42,8 @@ describe("Datum Builders", () => {
 
   const testRequest: ValidationRequest = {
     requesterDid: "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
-    proofCommitment: "proof123abc",
+    proofCommitment:
+      "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
     accessTime: 1704067200000,
     paymentAmount: 1_000_000n,
   }
@@ -217,6 +218,22 @@ describe("Datum Builders", () => {
 
       const result = buildAccessRedeemer(requestNoProof)
       expect(result.fields[1]).toBe("")
+    })
+
+    it("should pass through a valid 64-hex proof commitment", () => {
+      const result = buildAccessRedeemer(testRequest)
+      expect(result.fields[1]).toBe(testRequest.proofCommitment)
+    })
+
+    it("should reject a malformed proof commitment", () => {
+      const badRequest: ValidationRequest = {
+        ...testRequest,
+        proofCommitment: "proof123abc",
+      }
+
+      expect(() => buildAccessRedeemer(badRequest)).toThrow(
+        "Invalid proof commitment",
+      )
     })
 
     it("should serialize to CBOR", () => {

--- a/tests/integration/devnet-deploy.test.ts
+++ b/tests/integration/devnet-deploy.test.ts
@@ -11,7 +11,11 @@
 import { existsSync, readFileSync } from "node:fs"
 import { beforeAll, describe, expect, it } from "vitest"
 import { selectWalletFromSeed } from "../../src/lucid/provider.js"
-import type { LucidConfig, SPALPolicy } from "../../src/types.js"
+import type {
+  LucidConfig,
+  SPALPolicy,
+  ValidationRequest,
+} from "../../src/types.js"
 import { SPALEnforcer } from "../../src/validators/spal-enforcer.js"
 
 const YACI_STORE_URL = process.env.YACI_STORE_URL || "http://localhost:8080"
@@ -149,16 +153,18 @@ describe("Devnet Deployment", () => {
 
       // Create test policy
       testPolicy = {
-        version: 1n,
+        id: "integration-test-policy",
         ownerPkh: "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
         contextScope: "health.records",
         minPayment: 0n,
+        maxRetentionMs: 86_400_000,
         requiredProofHash: "",
         identityLinkage: {
           ephemeralRequired: false,
-          allowPersistent: true,
+          proofOfRootAllowed: true,
+          zkContinuityAllowed: false,
         },
-        retentionHours: 24n,
+        paymentCurrency: { kind: "Ada" },
       }
     })
 
@@ -168,9 +174,9 @@ describe("Devnet Deployment", () => {
     })
 
     it("should validate off-chain correctly", async () => {
-      const request = {
+      const request: ValidationRequest = {
         requesterDid: "did:key:z6MkTest...",
-        proofReference: "",
+        proofCommitment: "",
         accessTime: Math.floor(Date.now() / 1000),
         paymentAmount: 0n,
       }

--- a/tests/spal-enforcer.test.ts
+++ b/tests/spal-enforcer.test.ts
@@ -175,7 +175,8 @@ describe("SPALEnforcer", () => {
 
       const requestWithProof: ValidationRequest = {
         ...validRequest,
-        proofCommitment: "proof_hash_xyz123",
+        proofCommitment:
+          "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
       }
 
       const result = await enforcer.validate(policyWithProof, requestWithProof)

--- a/tests/spal-enforcer.test.ts
+++ b/tests/spal-enforcer.test.ts
@@ -32,7 +32,7 @@ describe("SPALEnforcer", () => {
 
   const validRequest: ValidationRequest = {
     requesterDid: "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
-    proofReference: "",
+    proofCommitment: "",
     accessTime: Date.now(),
     paymentAmount: 0n,
   }
@@ -164,10 +164,10 @@ describe("SPALEnforcer", () => {
 
       const result = await enforcer.validate(policyWithProof, validRequest)
       expect(result.valid).toBe(false)
-      expect(result.error).toContain("Proof reference required")
+      expect(result.error).toContain("Proof commitment required")
     })
 
-    it("should accept valid proof reference", async () => {
+    it("should accept valid proof commitment", async () => {
       const policyWithProof: SPALPolicy = {
         ...testPolicy,
         requiredProofHash: "abcd1234abcd1234",
@@ -175,7 +175,7 @@ describe("SPALEnforcer", () => {
 
       const requestWithProof: ValidationRequest = {
         ...validRequest,
-        proofReference: "proof_hash_xyz123",
+        proofCommitment: "proof_hash_xyz123",
       }
 
       const result = await enforcer.validate(policyWithProof, requestWithProof)


### PR DESCRIPTION
## Summary

Reshapes the S-PAL validator so the ZK public input is **reconstructed on-chain from trusted context** rather than accepted from the prover, closing the forgery/replay gap described in #15 and codified in [ADR-005](https://github.com/peteski22/pci-docs/blob/main/decisions/005-cardano-l1-vs-midnight-sidechain-for-zkp.md) ("the public-input pattern is portable").

Previously `AccessRedeemer.proof_reference` was an opaque blob, only length-checked — nothing bound a proof to the policy, requester, payment, or the UTxO being spent, so a proof valid for one policy could be replayed against another.

## What changed

**On-chain (`spal_validator/validators/spal.ak`)**
- `AccessRedeemer.proof_reference` → `proof_commitment` (a commitment to the off-chain proof artefact).
- New `reconstruct_public_input` computes `pub = blake2b_256(domain_sep ‖ script_hash ‖ spend_ref_hash ‖ policy_hash ‖ context_scope ‖ required_proof_hash ‖ subject_hash ‖ access_time ‖ payment_commitment)` — every component from trusted context (constant, script context, policy datum, constrained redeemer fields), all fixed-width so the encoding is unambiguous.
- When the policy requires a proof, the validator requires `proof_commitment == blake2b_256(pub)`. The prover can't substitute a public input — the validator computes one. Evaluated only when a proof is required.
- `check_proof_requirement` retained as the shape gate.
- Includes the spending `OutputReference` so `pub` is bound to the specific UTxO (prevents cross-UTxO replay within a deployment).
- 12 new tests (determinism, per-field/per-UTxO sensitivity, cross-subject/cross-UTxO replay rejection).

**Encoding spec (`spal_validator/PUBLIC_INPUT.md`)**
- Pins `domain_sep_spal`, field order, per-field canonicalisation, the interim commitment binding, and the `Fr` reduction — the canonical artefact pci-zkp and pci-spec must reproduce byte-for-byte.

**Off-chain SDK (TypeScript)**
- `proofReference` → `proofCommitment` across `types.ts`, `datum-builders.ts`, `spal-enforcer.ts` and tests; off-chain `validate()` keeps a shape check (binding is enforced on-chain).
- Fixed a stale `SPALPolicy` literal in the integration test.

## Interim scope (per #15 non-goals)

ZK verification stays off-chain — no on-chain Groth16 verifier here. `pub` is therefore publicly recomputable, so the on-chain check binds the redeemer to this exact context; proof-of-knowledge is established off-chain. Docstrings and the spec state this explicitly.

## Not in this PR (must land in lockstep)

- **pci-zkp**: circuit consumes the same `pub`, regenerate proving/verifying keys, prover inputs.
- **pci-spec**: pin the encoding.

A single differing byte between on-chain and off-chain rejects every proof — treat `PUBLIC_INPUT.md` as canonical.

## Validation

- Aiken `check`: 31/31, no warnings
- Biome lint / typecheck / build / Vitest (47): all pass
- Validators run: security, state-machine, error-handling, typescript-style (all green after fixes)

Refs #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Proof commitments are now bound to reconstructed transaction public inputs.
  - Deterministic payment commitments are generated from payment currency and amount.
  - Canonical public-input encoding and reproduction guidance were added.

- **Changes**
  - Validation requests and access redeemers now use `proofCommitment` instead of the previous proof reference.
  - When a policy requires a proof, non-empty proof commitments are required for successful validation.

- **Bug Fixes**
  - Improved replay resistance by enforcing commitment correctness against the underlying context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->